### PR TITLE
Send additional block data to OMS

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -447,11 +447,19 @@ Node.prototype.changed = function () {
 Node.prototype.prepareBlock = function () {
 	return {
 		nodeHostName: os.hostname(),
+		receivedBlockTimestamp: new Date().toISOString(),
 		id: this.id,
 		blockNumber: this.stats.block.number,
 		blockHash: this.stats.block.hash,
+		blockParentHash: this.stats.block.parentHash,
+		blockNonce: this.stats.block.nonce,
 		blockMiner: this.stats.block.miner,
 		blockTimestamp: new Date(this.stats.block.timestamp * 1000).toISOString(),
+		blockTransactionCount: this.stats.block.transactions.length,
+		blockUncleCount: this.stats.block.uncles.length,
+		blockExtraData: this.stats.block.extraData,
+		blockGasLimit: this.stats.block.gasLimit,
+		blockGasUsed: this.stats.block.gasUsed,
 	};
 }
 


### PR DESCRIPTION
Send the following additional fields when a new block is added to the chain.

- receivedBlockTimestamp = Current Date/Time when the web3 interface send the notification
- blockParentHash
- blockNonce
- blockTransactionCount
- blockUncleCount
- blockExtraData
- blockGasLimit
- blockGasUsed